### PR TITLE
Don't attempt to write out commit file when not running on Windows

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -14,8 +14,11 @@ custom-goals
 
 #create-commit-file target='compile'
   @{
-    var artifactsDir = Path.Combine(Directory.GetCurrentDirectory(), "artifacts");
-    var commitHashFile = Path.Combine(artifactsDir, "commit");
-    Directory.CreateDirectory(artifactsDir);
-    GitCommand("rev-parse HEAD >> " + commitHashFile);
+    if (!IsLinux)
+    {
+        var artifactsDir = Path.Combine(Directory.GetCurrentDirectory(), "artifacts");
+        var commitHashFile = Path.Combine(artifactsDir, "commit");
+        Directory.CreateDirectory(artifactsDir);
+        GitCommand("rev-parse HEAD >> " + commitHashFile);
+    }
   }


### PR DESCRIPTION
Doesn't seem to work:

```
[17:28:21][create-commit-file] Exec
[17:28:21][create-commit-file]   program: git
[17:28:21][create-commit-file]   commandline: rev-parse HEAD >> /Users/asplab/buildAgent/work/169923259d6dcfec/Universe/libuv-package/artifacts/commit
[17:28:21][create-commit-file]   workingdir: 
[17:28:21][create-commit-file] fatal: ambiguous argument '>>': unknown revision or path not in the working tree.
[17:28:21][create-commit-file] Use '--' to separate paths from revisions, like this:
[17:28:21][create-commit-file] 'git <command> [<revision>...] -- [<file>...]'
[17:28:21][create-commit-file] e40b1af734bcd500decf76b160bce4fbd0193b2f
[17:28:21][create-commit-file] >>
```

Ran into this as part of coreclr build
