### PR TITLE
Added reference to Microsoft.NETCore.Platforms

### DIFF
--- a/src/Libuv/project.json
+++ b/src/Libuv/project.json
@@ -25,6 +25,7 @@
     }
   },
   "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.AspNetCore.Internal.libuv-Darwin": {
       "version": "1.9.0-*",
       "type": "build"


### PR DESCRIPTION
- This allows this package to be restored without adding this reference manually. NuGet will know the supported RIDs.
- Hopefully @ericstj will split this package so it doesn't depend on **Microsoft.NETCore.Targets** (it's harmless right now anyways).

/cc @pranavkm @ericstj 